### PR TITLE
Remove unused orientation attribute for Relative Layout in xml

### DIFF
--- a/4-RecyclerView/src/main/res/layout/item_list.xml
+++ b/4-RecyclerView/src/main/res/layout/item_list.xml
@@ -18,7 +18,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"
-    android:orientation="vertical"
     android:padding="@dimen/md_keylines">
 
     <ImageView

--- a/4-RecyclerView/src/main/res/layout/item_tile.xml
+++ b/4-RecyclerView/src/main/res/layout/item_tile.xml
@@ -18,7 +18,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"
-    android:orientation="vertical"
     android:padding="@dimen/tile_padding">
 
     <ImageView

--- a/5-PageElement/src/main/res/layout/item_list.xml
+++ b/5-PageElement/src/main/res/layout/item_list.xml
@@ -18,7 +18,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"
-    android:orientation="vertical"
     android:padding="@dimen/md_keylines">
 
     <ImageView

--- a/5-PageElement/src/main/res/layout/item_tile.xml
+++ b/5-PageElement/src/main/res/layout/item_tile.xml
@@ -18,7 +18,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"
-    android:orientation="vertical"
     android:padding="@dimen/tile_padding">
 
     <ImageView

--- a/app/src/main/res/layout/item_list.xml
+++ b/app/src/main/res/layout/item_list.xml
@@ -18,7 +18,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"
-    android:orientation="vertical"
     android:padding="@dimen/md_keylines">
 
     <ImageView

--- a/app/src/main/res/layout/item_tile.xml
+++ b/app/src/main/res/layout/item_tile.xml
@@ -18,7 +18,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"
-    android:orientation="vertical"
     android:padding="@dimen/tile_padding">
 
     <ImageView


### PR DESCRIPTION
The xml orientation attribute was left in when changing from LinearLayout to RelativeLayout as the codelab progressed. No harm, but could cause confusion for some.
